### PR TITLE
Remove link-breaking ZWSPs

### DIFF
--- a/webdocs/compile.rst
+++ b/webdocs/compile.rst
@@ -42,7 +42,7 @@ Installation of compilers is highly depend on the computer system being used, bu
       conda install gfortran_osx-64 scons
 
 Use the ``conda search gfortran`` command to find the name for the package. 
-On most linux systems, one can use a command such as ``sudo apt-get gfortran`` or ``yum install gcc-gfortran``. Also see ​https://gcc.gnu.org/wiki/GFortranBinaries for more information.
+On most linux systems, one can use a command such as ``sudo apt-get gfortran`` or ``yum install gcc-gfortran``. Also see https://gcc.gnu.org/wiki/GFortranBinaries for more information.
 
 Note that the intent is that this Scons-based process will be replaced with one to run under meson in mid-2024. In the meantime, some older web pages discussing compiling GSAS-II may be of use:
 

--- a/webdocs/documentation.rst
+++ b/webdocs/documentation.rst
@@ -35,7 +35,7 @@ Developer's Documentation
 ----------------------------
 
 450+ pages of code documentation generated from comments in the code
-and RestructuredText documentation files are found on the `​"Read The
+and RestructuredText documentation files are found on the `"Read The
 Docs" web site <https://gsas-ii.readthedocs.io>`_. The documentation
 can also be downloaded as a
 `PDF document <https://gsas-ii.readthedocs.io/_/downloads/en/latest/pdf/>`_
@@ -54,7 +54,7 @@ Scripting Documentation
 
 The documentation on scripting GSAS-II is contained in the Developer's
 Documentation described immediately above, but an
-`abridged version of the ​web site
+`abridged version of the web site
 <https://gsas-ii-scripting.readthedocs.io/en/latest/>`_ with 
 only sections relevant to scripting is also available. This abridged
 version can also be downloaded as a `PDF document
@@ -68,6 +68,6 @@ Crystallography/Powder Diffraction Intro
 -----------------------------------------------
 
 For background material on powder diffraction crystallography, see the links
-on our ​
+on our 
 `Powder Diffraction Crystallography Educational Materials page <https://www.aps.anl.gov/Education/Powder-Diffraction-Educational-Materials>`_,
 in addition to the very considerable amount of material found on other sites.

--- a/webdocs/index.rst
+++ b/webdocs/index.rst
@@ -33,20 +33,20 @@ synchrotron x-rays, as well as constant wavelength or time-of-flight
 neutron sources. It provides structure solution and refinement, as
 well as extensive visualization capabilities. 
 
-GSAS-II is made available for free use (`see license <https://raw.githubusercontent.com/AdvancedPhotonSource/GSAS-II/master/LICENSE>`_) with open access to ​the `source code <https://github.com/AdvancedPhotonSource/GSAS-II>`_.  
+GSAS-II is made available for free use (`see license <https://raw.githubusercontent.com/AdvancedPhotonSource/GSAS-II/master/LICENSE>`_) with open access to the `source code <https://github.com/AdvancedPhotonSource/GSAS-II>`_.  
 
 .. tip::
     Please help us by citing:
 
      .. index:: Citation
     
-    Toby, B. H., & Von Dreele, R. B. (2013). "GSAS-II: the genesis of a modern open-source all purpose crystallography software package". *Journal of Applied Crystallography*, **46**\(2), 544-549. ​doi:10.1107/S0021889813003531
+    Toby, B. H., & Von Dreele, R. B. (2013). "GSAS-II: the genesis of a modern open-source all purpose crystallography software package". *Journal of Applied Crystallography*, **46**\(2), 544-549. doi:10.1107/S0021889813003531
 
        Note that some sections of the program utilize externally provided
        codes or reference later work, with citations provided
        as they are used. *Please* cite them as well.
  
-Also, please do sign up for the ​GSAS-II mailing list `see below <mailinglist.html>`_.
+Also, please do sign up for the GSAS-II mailing list `see below <mailinglist.html>`_.
 We add new features to GSAS-II quite frequently, so we may break
 things from time to time (`see bug reporting <bug.html>`_). Be
 sure to use the ``Help-->Update`` capability frequently to stay abreast of

--- a/webdocs/mailinglist.rst
+++ b/webdocs/mailinglist.rst
@@ -8,14 +8,14 @@ Mailing List
 =======================
 
 We provide a mailing list for GSAS-II users to ask questions and more importantly, **so that we can reach users with news about GSAS-II**. Please do subscribe. The level of traffic on this list is pretty low, perhaps a few e-mails a month; Bob and I usually reply to directly to the sender to further reduce this traffic, unless the answer will be valuable to many people.
-You can also search the `archives of the mailing list <​http://www.mail-archive.com/gsas-ii@mailman.aps.anl.gov/>`_.
+You can also search the `archives of the mailing list <http://www.mail-archive.com/gsas-ii@mailman.aps.anl.gov/>`_.
 
 .. index:: Subscribe to mailing list
 
 Subscribing
 -------------------
 To subscribe, use
-`​this link <https://mailman.aps.anl.gov/mailman/listinfo/GSAS-II>`_
+`this link <https://mailman.aps.anl.gov/mailman/listinfo/GSAS-II>`_
 or send an e-mail to `GSAS-II-request@mailman.aps.anl.gov  <GSAS-II-request@mailman.aps.anl.gov?subject=subscribe>`_.
 Set the subject as "Subscribe" (or "Subscribe <password>" where <password> is your preference for a mailing list login password). You can also use "Help" as the subject to get a list of options 
 


### PR DESCRIPTION
Removes zero-width spaces (U+200B), some of which were breaking links in mailinglist.rst and compile.rst